### PR TITLE
Set minimum mistune version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pandas
 pyarrow
 numpy
 matplotlib
-mistune
+mistune>=3.0.2
 pyyaml
 plotly
 plotly-express


### PR DESCRIPTION
"math" plugin not available in previous versions of mistune